### PR TITLE
Fix installation directory name in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,4 +51,4 @@ Commands for project configuration and tooling setup.
 
 ---
 
-For detailed information about each release, see the [GitHub Releases](https://github.com/your-org/claude-rules/releases) page.
+For detailed information about each release, see the [GitHub Releases](https://github.com/qdhenry/Claude-Command-Suite/releases) page.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Custom slash commands for Claude Code that provide structured workflows for comm
 1. **Install the commands:**
    ```bash
    git clone https://github.com/qdhenry/Claude-Command-Suite.git
-   cd claude-rules
+   cd Claude-Command-Suite
    chmod +x install.sh
    ./install.sh
    ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -10,7 +10,7 @@ Guide for contributing to claude-rules, testing commands, and following best pra
    ```bash
    git fork https://github.com/qdhenry/Claude-Command-Suite.git
    git clone <your-fork-url>
-   cd claude-rules
+   cd Claude-Command-Suite
    ```
 
 2. **Set Up Development Environment:**

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -9,7 +9,7 @@ Use the provided installation script for easy setup:
 ```bash
 # Clone or download this repository
 git clone https://github.com/qdhenry/Claude-Command-Suite.git
-cd claude-rules
+cd Claude-Command-Suite
 
 # Make the installer executable and run it
 chmod +x install.sh


### PR DESCRIPTION
## Summary
Fixes #5 - Corrects the installation directory name from `claude-rules` to `Claude-Command-Suite` in all documentation.

## Problem
The installation instructions incorrectly told users to `cd claude-rules` after cloning the repository, but the actual directory created when cloning is `Claude-Command-Suite`.

## Changes Made
- Updated `README.md` quick start installation instructions
- Updated `docs/INSTALLATION.md` installation guide  
- Updated `docs/DEVELOPMENT.md` development setup instructions
- Updated `CHANGELOG.md` GitHub releases URL to point to correct repository

## Testing
- Verified all instances of incorrect directory references have been fixed
- Checked that no valid references to "claude-rules" were incorrectly changed
- Confirmed installation instructions now match the actual cloned directory name

## Impact
This fix ensures new users can successfully follow the installation instructions without encountering directory navigation errors.

🤖 Generated with [Claude Code](https://claude.ai/code)