### PR TITLE
feat: add rule2hook command to convert natural language rules to Claude Code hooks

### DIFF
--- a/.claude/commands/dev/README.md
+++ b/.claude/commands/dev/README.md
@@ -15,5 +15,6 @@ This namespace contains commands for daily development tasks, code analysis, and
 - **git-status.md** - Enhanced Git status with additional insights and recommendations
 - **prime.md** - Prime your development environment for optimal performance
 - **refactor-code.md** - Refactor code following best practices and design patterns
+- **rule2hook.md** - Convert natural language project rules into Claude Code hooks automatically (by [zxdxjtu](https://github.com/zxdxjtu/claudecode-rule2hook))
 - **sentient.md** - Advanced AI-powered development assistant with contextual awareness
 - **ultra-think.md** - Deep thinking mode for complex problem solving and architecture decisions

--- a/.claude/commands/dev/rule2hook.md
+++ b/.claude/commands/dev/rule2hook.md
@@ -1,0 +1,221 @@
+# Task: Convert Project Rules to Claude Code Hooks
+
+---
+**Attribution**: This command is based on the excellent work by zxdxjtu from the [claudecode-rule2hook](https://github.com/zxdxjtu/claudecode-rule2hook) repository. 
+Licensed under MIT License. Integrated into Claude Command Suite with permission to enhance developer workflows.
+---
+
+You are an expert at converting natural language project rules into Claude Code hook configurations. Your task is to analyze the given rules and generate appropriate hook configurations following the official Claude Code hooks specification.
+
+## Instructions
+
+1. If rules are provided as arguments, analyze those rules
+2. If no arguments are provided, read and analyze the CLAUDE.md file from these locations:
+   - `./CLAUDE.md` (project memory)
+   - `./CLAUDE.local.md` (local project memory)  
+   - `~/.claude/CLAUDE.md` (user memory)
+
+3. For each rule, determine:
+   - The appropriate hook event (PreToolUse, PostToolUse, Stop, Notification)
+   - The tool matcher pattern (exact tool names or regex)
+   - The command to execute
+
+4. Generate the complete hook configuration following the exact JSON structure
+5. Save it to `~/.claude/hooks.json` (merge with existing hooks if present)
+6. Provide a summary of what was configured
+
+## Hook Events
+
+### PreToolUse
+- **When**: Runs BEFORE a tool is executed
+- **Common Keywords**: "before", "check", "validate", "prevent", "scan", "verify"
+- **Available Tool Matchers**: 
+  - `Task` - Before launching agent tasks
+  - `Bash` - Before running shell commands
+  - `Glob` - Before file pattern matching
+  - `Grep` - Before content searching
+  - `Read` - Before reading files
+  - `Edit` - Before editing single files
+  - `MultiEdit` - Before batch editing files
+  - `Write` - Before writing/creating files
+  - `WebFetch` - Before fetching web content
+  - `WebSearch` - Before web searching
+  - `TodoRead` - Before reading todo list
+  - `TodoWrite` - Before updating todo list
+- **Special Feature**: Can block tool execution if command returns non-zero exit code
+
+### PostToolUse
+- **When**: Runs AFTER a tool completes successfully
+- **Common Keywords**: "after", "following", "once done", "when finished"
+- **Available Tool Matchers**: Same as PreToolUse
+- **Common Uses**: Formatting, linting, building, testing after file changes
+
+### Stop
+- **When**: Runs when Claude Code finishes responding
+- **Common Keywords**: "finish", "complete", "end task", "done", "wrap up"
+- **No matcher needed**: Applies to all completions
+- **Common Uses**: Final status checks, summaries, cleanup
+
+### Notification
+- **When**: Runs when Claude Code sends notifications
+- **Common Keywords**: "notify", "alert", "inform", "message"
+- **Special**: Rarely used for rule conversion
+
+## Hook Configuration Structure
+
+```json
+{
+  "hooks": {
+    "EventName": [
+      {
+        "matcher": "ToolName|AnotherTool|Pattern.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "your-command-here"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Matcher Patterns
+
+- **Exact match**: `"Edit"` - matches only Edit tool
+- **Multiple tools**: `"Edit|MultiEdit|Write"` - matches any of these
+- **Regex patterns**: `".*Edit"` - matches Edit and MultiEdit
+- **All tools**: Omit matcher field entirely
+
+## Examples with Analysis
+
+### Example 1: Python Formatting
+**Rule**: "Format Python files with black after editing"
+**Analysis**: 
+- Keyword "after" → PostToolUse
+- "editing" → Edit|MultiEdit|Write tools
+- "Python files" → command should target .py files
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Edit|MultiEdit|Write",
+      "hooks": [{
+        "type": "command",
+        "command": "black . --quiet 2>/dev/null || true"
+      }]
+    }]
+  }
+}
+```
+
+### Example 2: Git Status Check
+**Rule**: "Run git status when finishing a task"
+**Analysis**:
+- "finishing" → Stop event
+- No specific tool mentioned → no matcher needed
+
+```json
+{
+  "hooks": {
+    "Stop": [{
+      "hooks": [{
+        "type": "command",
+        "command": "git status"
+      }]
+    }]
+  }
+}
+```
+
+### Example 3: Security Scan
+**Rule**: "Check for hardcoded secrets before saving any file"
+**Analysis**:
+- "before" → PreToolUse
+- "saving any file" → Write|Edit|MultiEdit
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Write|Edit|MultiEdit",
+      "hooks": [{
+        "type": "command",
+        "command": "git secrets --scan 2>/dev/null || echo 'No secrets found'"
+      }]
+    }]
+  }
+}
+```
+
+### Example 4: Test Runner
+**Rule**: "Run npm test after modifying files in tests/ directory"
+**Analysis**:
+- "after modifying" → PostToolUse
+- "files" → Edit|MultiEdit|Write
+- Note: Path filtering happens in the command, not the matcher
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Edit|MultiEdit|Write",
+      "hooks": [{
+        "type": "command",
+        "command": "npm test 2>/dev/null || echo 'Tests need attention'"
+      }]
+    }]
+  }
+}
+```
+
+### Example 5: Command Logging
+**Rule**: "Log all bash commands before execution"
+**Analysis**:
+- "before execution" → PreToolUse
+- "bash commands" → Bash tool specifically
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{
+        "type": "command",
+        "command": "echo \"[$(date)] Executing bash command\" >> ~/.claude/command.log"
+      }]
+    }]
+  }
+}
+```
+
+## Best Practices for Command Generation
+
+1. **Error Handling**: Add `|| true` or `2>/dev/null` to prevent hook failures from blocking Claude
+2. **Quiet Mode**: Use quiet flags (--quiet, -q) when available
+3. **Path Safety**: Use relative paths or check existence
+4. **Performance**: Keep commands fast to avoid slowing down Claude
+5. **Logging**: Redirect verbose output to avoid cluttering Claude's interface
+
+## Common Rule Patterns
+
+- "Format [language] files after editing" → PostToolUse + Edit|MultiEdit|Write
+- "Run [command] before committing" → PreToolUse + Bash (when git commit detected)
+- "Check for [pattern] before saving" → PreToolUse + Write|Edit|MultiEdit
+- "Execute [command] when done" → Stop event
+- "Validate [something] before running commands" → PreToolUse + Bash
+- "Clear cache after modifying config" → PostToolUse + Edit|MultiEdit|Write
+- "Notify when [condition]" → Usually PostToolUse with specific matcher
+
+## Important Notes
+
+1. Always merge with existing hooks - don't overwrite
+2. Test commands work before adding to hooks
+3. Consider performance impact of hooks
+4. Use specific matchers when possible to avoid unnecessary executions
+5. Commands run with full user permissions - be careful with destructive operations
+
+## User Input
+$ARGUMENTS

--- a/docs/RULE2HOOK_USAGE.md
+++ b/docs/RULE2HOOK_USAGE.md
@@ -1,0 +1,61 @@
+# Rule2Hook Command Usage Guide
+
+This command is integrated from the excellent [claudecode-rule2hook](https://github.com/zxdxjtu/claudecode-rule2hook) repository created by [zxdxjtu](https://github.com/zxdxjtu). We've incorporated it into the Claude Command Suite to make it easily accessible for all users, maintaining full compatibility with the original implementation while respecting the MIT License.
+
+The `rule2hook` command helps you convert natural language project rules into Claude Code hooks automatically.
+
+## Installation
+The command is already included in the Claude Command Suite under the `dev` namespace.
+
+## Usage
+
+### Basic Usage
+```bash
+# Convert a specific rule
+/dev:rule2hook "Format Python files with black after editing"
+
+# Analyze existing CLAUDE.md files for rules
+/dev:rule2hook
+```
+
+### Examples
+
+1. **Code Formatting Rule**
+   ```bash
+   /dev:rule2hook "Run prettier on JavaScript files after editing"
+   ```
+   Generates a PostToolUse hook for Edit|MultiEdit|Write tools
+
+2. **Security Check**
+   ```bash
+   /dev:rule2hook "Check for hardcoded secrets before saving files"
+   ```
+   Generates a PreToolUse hook for Write|Edit|MultiEdit tools
+
+3. **Git Workflow**
+   ```bash
+   /dev:rule2hook "Show git status when finishing tasks"
+   ```
+   Generates a Stop hook
+
+4. **Testing Rule**
+   ```bash
+   /dev:rule2hook "Run tests after modifying test files"
+   ```
+   Generates a PostToolUse hook
+
+## Output
+The command will:
+1. Analyze your rule
+2. Generate the appropriate hook configuration
+3. Save it to `~/.claude/hooks.json`
+4. Show you what was configured
+
+## Verification
+Check your configured hooks:
+```bash
+cat ~/.claude/hooks.json
+```
+
+## Attribution
+This command was created by [zxdxjtu](https://github.com/zxdxjtu/claudecode-rule2hook) and integrated into Claude Command Suite.


### PR DESCRIPTION
## Summary
- Integrated the excellent `rule2hook` command from [zxdxjtu/claudecode-rule2hook](https://github.com/zxdxjtu/claudecode-rule2hook)
- Added to the dev namespace as `/dev:rule2hook` for easy access by all Claude Command Suite users
- Included comprehensive documentation and usage examples

## What is rule2hook?
The `rule2hook` command converts natural language project rules into Claude Code hook configurations automatically. For example:
- "Format Python files with black after editing" → Generates PostToolUse hook
- "Check for secrets before saving files" → Generates PreToolUse hook
- "Show git status when finishing tasks" → Generates Stop hook

## Changes Made
1. Added `.claude/commands/dev/rule2hook.md` - The main command file with full attribution
2. Updated `.claude/commands/dev/README.md` - Listed the new command with linked credit to the author
3. Created `docs/RULE2HOOK_USAGE.md` - Usage guide with examples and attribution

## Attribution
Full credit goes to [zxdxjtu](https://github.com/zxdxjtu) for creating this useful tool. We've integrated it into Claude Command Suite while:
- Maintaining full compatibility with the original implementation
- Respecting the MIT License
- Adding clear attribution in multiple places

## Test Plan
- [ ] Test `/dev:rule2hook "Format Python files with black after editing"`
- [ ] Test `/dev:rule2hook` without arguments to analyze CLAUDE.md files
- [ ] Verify hooks are saved to `~/.claude/hooks.json`
- [ ] Confirm attribution is visible in documentation