### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Claude Command Suite
 
+[![Run in Smithery](https://smithery.ai/badge/skills/qdhenry)](https://smithery.ai/skills?ns=qdhenry&utm_source=github&utm_medium=badge)
+
+
 ![Total Commands](https://img.shields.io/badge/Commands-148-brightgreen?style=for-the-badge)
 ![AI Agents](https://img.shields.io/badge/AI_Agents-54-red?style=for-the-badge)
 ![GitHub Release](https://img.shields.io/github/v/release/qdhenry/Claude-Command-Suite?style=for-the-badge)


### PR DESCRIPTION
## Add skill discoverability badge

Your 2 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/qdhenry)](https://smithery.ai/skills?ns=qdhenry&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.